### PR TITLE
Fix: Reverse drag direction to match mouse movement

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,8 +337,8 @@
                 const deltaY = event.clientY - previousMousePosition.y;
 
                 // The rotation direction is now mapped to move with the mouse
-                nebulaGroup.rotation.y += deltaX * 0.002;
-                nebulaGroup.rotation.x += deltaY * 0.002;
+                nebulaGroup.rotation.y -= deltaX * 0.002;
+                nebulaGroup.rotation.x -= deltaY * 0.002;
 
                 previousMousePosition.x = event.clientX;
                 previousMousePosition.y = event.clientY;


### PR DESCRIPTION
The click and drag functionality for the awesome menu was moving in the opposite direction of the mouse. This was because the mouse movement deltas were being added to the rotation of the scene.

This commit fixes the issue by subtracting the mouse deltas from the rotation, which makes the drag movement match the mouse direction.