### PR TITLE
Fix: Make content below Earth visible on Join page

### DIFF
--- a/join.html
+++ b/join.html
@@ -24,7 +24,6 @@
             text-align: center;
             padding: 20px;
             position: relative;
-            overflow: hidden;
         }
         
         #earth-canvas {

--- a/styles/main.css
+++ b/styles/main.css
@@ -82,4 +82,6 @@ hr.neon-divider {
 /* --- Page Load Animation --- */
 .content-container {
     opacity: 0;
+    position: relative;
+    z-index: 2;
 }


### PR DESCRIPTION
The content on the Join page below the hero section was not visible due to a combination of CSS properties.

- Removed `overflow: hidden` from the `.hero` class in `join.html` to allow scrolling to the content below it.
- Added `position: relative` and `z-index: 2` to the `.content-container` class in `styles/main.css` to ensure it is stacked above the hero section's canvas element.