### PR TITLE
Fix: Prevent JS error and ensure content visibility

### DIFF
--- a/js/particle-animation.js
+++ b/js/particle-animation.js
@@ -1,52 +1,53 @@
-// --- Scene Setup ---
-const scene = new THREE.Scene();
-const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
-const renderer = new THREE.WebGLRenderer({
-    canvas: document.querySelector('#particle-canvas'),
-});
+const particleCanvas = document.querySelector('#particle-canvas');
 
-renderer.setPixelRatio(window.devicePixelRatio);
-renderer.setSize(window.innerWidth, window.innerHeight);
-camera.position.setZ(30);
+if (particleCanvas) {
+    // --- Scene Setup ---
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+    const renderer = new THREE.WebGLRenderer({
+        canvas: particleCanvas,
+    });
 
-// --- Starfield ---
-const starGeometry = new THREE.BufferGeometry();
-const starMaterial = new THREE.PointsMaterial({
-    color: 0xffffff,
-    size: 0.05,
-    transparent: true,
-    opacity: 0.5
-});
-
-const starVertices = [];
-for (let i = 0; i < 10000; i++) {
-    const x = (Math.random() - 0.5) * 200;
-    const y = (Math.random() - 0.5) * 200;
-    const z = (Math.random() - 0.5) * 200;
-    starVertices.push(x, y, z);
-}
-
-starGeometry.setAttribute('position', new THREE.Float32BufferAttribute(starVertices, 3));
-const starField = new THREE.Points(starGeometry, starMaterial);
-scene.add(starField);
-
-// --- Animation Loop ---
-function animate() {
-    requestAnimationFrame(animate);
-
-    starField.rotation.y += 0.0001;
-
-    renderer.render(scene, camera);
-}
-
-animate();
-
-// --- On Resize ---
-window.addEventListener('resize', () => {
-    camera.aspect = window.innerWidth / window.innerHeight;
-    camera.updateProjectionMatrix();
+    renderer.setPixelRatio(window.devicePixelRatio);
     renderer.setSize(window.innerWidth, window.innerHeight);
-});
+    camera.position.setZ(30);
+
+    // --- Starfield ---
+    const starGeometry = new THREE.BufferGeometry();
+    const starMaterial = new THREE.PointsMaterial({
+        color: 0xffffff,
+        size: 0.05,
+        transparent: true,
+        opacity: 0.5
+    });
+
+    const starVertices = [];
+    for (let i = 0; i < 10000; i++) {
+        const x = (Math.random() - 0.5) * 200;
+        const y = (Math.random() - 0.5) * 200;
+        const z = (Math.random() - 0.5) * 200;
+        starVertices.push(x, y, z);
+    }
+
+    starGeometry.setAttribute('position', new THREE.Float32BufferAttribute(starVertices, 3));
+    const starField = new THREE.Points(starGeometry, starMaterial);
+    scene.add(starField);
+
+    // --- Animation Loop ---
+    function animate() {
+        requestAnimationFrame(animate);
+        starField.rotation.y += 0.0001;
+        renderer.render(scene, camera);
+    }
+    animate();
+
+    // --- On Resize ---
+    window.addEventListener('resize', () => {
+        camera.aspect = window.innerWidth / window.innerHeight;
+        camera.updateProjectionMatrix();
+        renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+}
 
 // --- GSAP Animations ---
 gsap.to(".content-container", {


### PR DESCRIPTION
This commit addresses the issue of hidden content on the `join.html` page by tackling two problems:

1.  A JavaScript error in `js/particle-animation.js` was occurring because the script was trying to access a non-existent canvas element (`#particle-canvas`) on the `join.html` page. This error prevented the GSAP animation from running, which was responsible for making the content visible. The script has been made more robust by wrapping the canvas-specific code in a conditional check.

2.  CSS properties were hiding the content. `overflow: hidden` was removed from the `.hero` element, and the `.content-container` was given a proper stacking context with `position: relative` and `z-index: 2`.