### PR TITLE
Update links on the initiatives page

### DIFF
--- a/initiatives.html
+++ b/initiatives.html
@@ -148,7 +148,7 @@
                         <p class="text-lg text-gray-300 max-w-4xl">
                            A global celebration of our shared humanity, powered by collective action. Governed by our DAO, the community will hold a global vote to launch a new Arts & Music Festival, culminating in a <strong>"Live Aid 2035"</strong> event to fund regenerative projects worldwide. This is a platform for joy, creativity, and direct democratic action.
                         </p>
-                        <a href="#" class="learn-more-link">Join the Movement &rarr;</a>
+                        <a href="https://auraofintelligence.github.io/GAJRA-earth/index.html" class="learn-more-link">Join the Movement &rarr;</a>
                     </div>
                 </div>
             </section>
@@ -164,7 +164,7 @@
                         <p class="text-lg text-gray-300 max-w-4xl">
                            Where the digital blueprint touches the earth. Our vision comes alive on Minjerribah through tangible, community-focused projects. We are launching the <strong>Quandamooka Film Festival</strong>, powered by our AI Storytelling tools, and developing the <strong>Straddie Sandy Sports Club</strong> into a multi-purpose precinct for sports, outdoor cinema, and cultural events.
                         </p>
-                        <a href="#" class="learn-more-link">See Local Projects &rarr;</a>
+                        <a href="https://auraofintelligence.github.io/amity-point/index.html" class="learn-more-link">See Local Projects &rarr;</a>
                     </div>
                 </div>
             </section>
@@ -180,7 +180,7 @@
                         <p class="text-lg text-gray-300 max-w-4xl">
                             An economic engine designed to rebalance the scales and empower a new generation of founders. This is a three-phase venture fund to support women-led ventures, starting with a proof-of-concept in Queensland and scaling to a global G20 initiative. We provide capital, mentorship, and a powerful community to create a more equitable world.
                         </p>
-                        <a href="#" class="learn-more-link">Empower the Future &rarr;</a>
+                        <a href="https://auraofintelligence.github.io/Queens_Venture/index.html" class="learn-more-link">Empower the Future &rarr;</a>
                     </div>
                 </div>
             </section>
@@ -196,7 +196,7 @@
                         <p class="text-lg text-gray-300 max-w-4xl">
                             What if technology could help us preserve the essence of who we are? This specialized application of Aura is designed to assist individuals with memory loss and neurodiverse needs. Our pragmatic clinical pathway aims to deliver a powerful tool for cognitive health, providing compassionate support for individuals and their caregivers.
                         </p>
-                        <a href="#" class="learn-more-link">Discover the Clinical Path &rarr;</a>
+                        <a href="https://auraofintelligence.github.io/aura-dementia/index.html" class="learn-more-link">Discover the Clinical Path &rarr;</a>
                     </div>
                 </div>
             </section>
@@ -212,7 +212,7 @@
                         <p class="text-lg text-gray-300 max-w-4xl">
                            Your personal sanctuary for deep healing and self-discovery. The Aura Geode is our core physical technology: a crystal-infused hyperbaric oxygen therapy (HBOT) pod where you create your digital twin and undergo personalized wellness protocols. This makes the most advanced aspects of our ecosystem tangible, accessible, and transformative.
                         </p>
-                        <a href="#" class="learn-more-link">Experience the Geode &rarr;</a>
+                        <a href="https://auraofintelligence.github.io/aura-geode/aura-geode-hbot.html" class="learn-more-link">Experience the Geode &rarr;</a>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
This commit updates the placeholder links on the initiatives page with the correct URLs for each initiative, as specified in the task.

The following links have been updated:
- GAJRA Earth
- Minjerribah (The Home Base)
- 500 Queens Venture Capital
- Aura for Dementia
- Aura Geode