### PR TITLE
feat: Update links on vision and library pages

### DIFF
--- a/library.html
+++ b/library.html
@@ -53,6 +53,10 @@
                 <p class="mt-4 text-lg text-gray-300 max-w-4xl">
                     The Library is a dedicated, searchable resource hub providing access to all source documents, research papers, technical specifications, and community-generated content. It is the transparent and open-source foundation of our entire project, ensuring that everyone has the opportunity to learn, contribute, and build upon our collective knowledge.
                 </p>
+                <div class="mt-6 flex space-x-4">
+                    <a href="library.html" class="learn-more-link">Explore the Library &rarr;</a>
+                    <a href="initiatives.html" class="learn-more-link">See our Initiatives &rarr;</a>
+                </div>
             </section>
 
             <!-- Card 2: PDF Library -->

--- a/vision.html
+++ b/vision.html
@@ -137,7 +137,16 @@
                         <p class="text-lg text-gray-300 max-w-4xl">
                             What if our economy valued connection as much as currency? The Regenerative Protocol is our answer. It's a new social and economic architecture built on the principle of a <strong>"Braided Economy,"</strong> weaving together traditional financial capital with the natural, social, and human capital our current system overlooks.
                         </p>
-                        <a href="#" class="learn-more-link">Explore the Economy &rarr;</a>
+                        <div class="mt-6">
+                            <h3 class="text-xl font-semibold text-cyan-400 mb-3">Explore the Protocol:</h3>
+                            <ul class="space-y-2 text-lg">
+                                <li><a href="docs/The Braided Economy Mandate_  Integrating Regenerative Principles into U.S. Digital Asset Legislation.pdf" class="learn-more-link" target="_blank">The Braided Economy Mandate &rarr;</a></li>
+                                <li><a href="docs/Version7 Aura of Intelligence 2023 July.pdf" class="learn-more-link" target="_blank">Aura of Intelligence v7 (July 2023) &rarr;</a></li>
+                                <li><a href="docs/01 Regenerative Civilization Protocol.pdf" class="learn-more-link" target="_blank">Regenerative Civilization Protocol &rarr;</a></li>
+                                <li><a href="docs/System Integration and Implementation Plan.pdf" class="learn-more-link" target="_blank">System Integration and Implementation Plan &rarr;</a></li>
+                                <li><a href="library.html" class="learn-more-link">Visit the full Library &rarr;</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
- Replaced the single "Explore the Economy" link on the vision page with a list of links to relevant PDF documents and the library page.
- Added links to the Library and Initiatives pages on the library page for easier navigation.